### PR TITLE
Fixes docstring of `Gallery`

### DIFF
--- a/nhentaio/gallery.py
+++ b/nhentaio/gallery.py
@@ -88,8 +88,6 @@ class Gallery:
         A UTC+0 datetime representing when this gallery was uploaded.
     favourites: :class:`int`
         The amount of favourites this gallery has received.
-    url: :class:`str`
-        The full URL for this gallery.
     pages: List[:class:`~.GalleryPage`]
         The pages in this gallery.
     similar: List[:class:`~.PartialGallery`]

--- a/nhentaio/gallery.py
+++ b/nhentaio/gallery.py
@@ -67,7 +67,6 @@ class Gallery:
     """Gallery()
 
     Represents an nhentai gallery.
-    This class is returned from :meth:`~.Client.fetch_gallery` / :meth:`~.Client.fetch_galleries` and should not be instantiated manually.
 
     Attributes
     -----------

--- a/nhentaio/gallery.py
+++ b/nhentaio/gallery.py
@@ -67,6 +67,7 @@ class Gallery:
     """Gallery()
 
     Represents an nhentai gallery.
+    This class is returned from :meth:`~.Client.fetch_gallery` / :meth:`~.Client.fetch_galleries` and should not be instantiated manually.
 
     Attributes
     -----------


### PR DESCRIPTION
The docstring of `Gallery.url` was repeated 2 times.